### PR TITLE
fix error when keyword is empty

### DIFF
--- a/lib/ruboty/handlers/misawa.rb
+++ b/lib/ruboty/handlers/misawa.rb
@@ -11,11 +11,16 @@ module Ruboty
 
       def misawa(message={})
         keyword = message[:keyword]
-        m = meigens.select{|meigen|
-          %w(title character body).any? {|key|
-            meigen[key] and meigen[key].include?(keyword)
-          }
-        }.sample
+        unless keyword.nil?
+          m = meigens.select{|meigen|
+            %w(title character body).any? {|key|
+              meigen[key] and meigen[key].include?(keyword)
+            }
+          }.sample
+        end
+        if keyword.nil? || m.nil?
+          m = meigens.sample
+        end
         if m then
           message.reply m['image']
         end


### PR DESCRIPTION
#1 の issue でご報告したエラーを修正しました。ご確認をお願いします。
1. keyword の指定がない場合（例: `@ruboty: misawa` ）にエラーが発生し ruboty が止まってしまう不具合を修正しました
2. keyword の指定がない場合にはランダムで画像を表示するように修正しました
   - レスポンスが何もないとリクエストが受け付けられたかどうかの判断がつかないため
   - 「あの画像を表示したい」と思って keyword を指定してリクエストしたら「全然違う画像が表示される」のは面白いかと思い、そのように修正しました
